### PR TITLE
Status message is added from the Space API.

### DIFF
--- a/spaceapi-osx/SAPIAppController.h
+++ b/spaceapi-osx/SAPIAppController.h
@@ -14,6 +14,7 @@
 @property (weak) IBOutlet NSMenu *mainMenu;
 @property (weak) IBOutlet NSMenu *spacesMenu;
 @property (weak) IBOutlet NSMenuItem *selectedSpaceItem;
+@property (weak) IBOutlet NSMenuItem *selectedSpaceMessage;
 
 - (IBAction)showPreferencePanel:(NSMenuItem *)sender;
 - (IBAction)selectSpaceFromMenu:(NSMenuItem *)sender;

--- a/spaceapi-osx/SAPIAppController.m
+++ b/spaceapi-osx/SAPIAppController.m
@@ -117,6 +117,10 @@
 - (void)handleOpenStatusChange:(NSNotification *)notification
 {
     self.statusItem.image = [[[notification userInfo] objectForKey:@"openStatus"] boolValue] ? self.greenLight : self.redLight;
+    NSString *statusMessage = [[notification userInfo] objectForKey:@"statusMessage"];
+    self.selectedSpaceMessage.title = statusMessage ?: @"Space: no message";
+    self.selectedSpaceMessage.hidden = statusMessage == nil;
+
 }
 
 - (void)fetchSpaceDirectory

--- a/spaceapi-osx/SAPISpace.m
+++ b/spaceapi-osx/SAPISpace.m
@@ -49,16 +49,23 @@ NSString * const SAPIOpenStatusChangedNotification = @"SAPIOpenStatusChanged";
 
             if (!jsonError) {
                 NSNumber *openStatus;
+                NSString *statusMessage;
                 NSString *version = [_spaceData objectForKey:@"api"];
 
                 if (version) {
                     if ([version isEqualToString:@"0.11"] || [version isEqualToString:@"0.12"]) {
                         openStatus = [_spaceData objectForKey:@"open"];
+                        statusMessage = [_spaceData objectForKey:@"status"];
                     } else {
                         openStatus = [[_spaceData objectForKey:@"state"] objectForKey:@"open"];
+                        statusMessage = [[_spaceData objectForKey:@"state"] objectForKey:@"message"];
                     }
 
-                    [[NSNotificationCenter defaultCenter] postNotificationName:SAPIOpenStatusChangedNotification object:self userInfo:[NSDictionary dictionaryWithObject:openStatus forKey:@"openStatus"]];
+                    NSDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:openStatus forKey:@"openStatus"];
+                    if (statusMessage) {
+                        [userInfo setValue:statusMessage forKey:@"statusMessage"];
+                    }
+                    [[NSNotificationCenter defaultCenter] postNotificationName:SAPIOpenStatusChangedNotification object:self userInfo:userInfo];
 
                     [self setOpen:[openStatus boolValue]];
                 }

--- a/spaceapi-osx/en.lproj/MainMenu.xib
+++ b/spaceapi-osx/en.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7531" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="5056"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -10,10 +10,13 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <menu id="536">
             <items>
                 <menuItem title="Space: no space selected" id="537">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                </menuItem>
+                <menuItem title="Space: no message" id="7vg-aY-J2o">
                     <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
                 <menuItem title="Update Status" id="538">
@@ -56,6 +59,7 @@
             <connections>
                 <outlet property="mainMenu" destination="536" id="552"/>
                 <outlet property="selectedSpaceItem" destination="537" id="560"/>
+                <outlet property="selectedSpaceMessage" destination="7vg-aY-J2o" id="VNb-vL-RBZ"/>
                 <outlet property="spacesMenu" destination="554" id="556"/>
             </connections>
         </customObject>


### PR DESCRIPTION
Status messages from the API is added as a Menu Item. 
If there is no message, the item becomes hidden. 

Feel free to comment and I can change anything you want. I tried to implement it according to your coding style. 

-------------------------------------

Here are the screenshots for couple of use cases. 

Custom messages from spaces are shown:
![screen shot 2015-07-14 at 17 23 50](https://cloud.githubusercontent.com/assets/763339/8675544/3a36f7f2-2a4d-11e5-8bd6-1c1c998463d9.png)
![screen shot 2015-07-14 at 17 23 14](https://cloud.githubusercontent.com/assets/763339/8675545/3a3d9d14-2a4d-11e5-9531-2acc0f524be0.png)


Closed without any message:
![screen shot 2015-07-14 at 17 23 33](https://cloud.githubusercontent.com/assets/763339/8675546/3a42ec24-2a4d-11e5-9e94-255693e951b6.png)


