### PR TITLE
Update URL to Space API directory

### DIFF
--- a/spaceapi-osx/spaceapi-osx-Prefix.pch
+++ b/spaceapi-osx/spaceapi-osx-Prefix.pch
@@ -22,7 +22,7 @@
 #endif
 
 // URLS
-#define kURL_SPACE_DIRECTORY                            @"http://spaceapi.net/directory.json"
+#define kURL_SPACE_DIRECTORY                            @"https://spaceapi.fixme.ch/directory.json"
 
 // LOGGING
 #define LOG( someString, ... )                          if( DEBUG ) NSLog( someString, ##__VA_ARGS__ )


### PR DESCRIPTION
The old URL seems to be down and according to the [website](http://spaceapi.net/) an alternative URL should be used. This PR updated the old URL to the suggested one.